### PR TITLE
Handele exceptions more graceful.

### DIFF
--- a/src/nudge/exceptions.py
+++ b/src/nudge/exceptions.py
@@ -1,16 +1,24 @@
-
-
 class BaseNudgeException(Exception):
-    "This is the base Nudge Exception, and you probably shouldn't use it"
+    """Base class for all Nudge exceptions. Should never be raised directly"""
     pass
-    
+
+
+class CommandException(BaseNudgeException):
+    """An exception occurred while trying to perform a remote Nudge command"""
+
+    def __init__(self, msg, orig_exception):
+        self.orig_exception = orig_exception
+        self.msg = msg
+
+
 class BatchValidationError(BaseNudgeException):
     "This batch contains an error"
     
-    def __init__(self,batch):
-        self.batch=batch
-        self.msg="Batch Validation Failed"
-        
+    def __init__(self, batch):
+        self.batch = batch
+        self.msg = "Batch Validation Failed"
+
+
 class BatchPushFailure(BaseNudgeException):
     "Pushing this batch failed"
     

--- a/src/nudge/views.py
+++ b/src/nudge/views.py
@@ -1,26 +1,21 @@
+import json
+from django.conf import settings
+from django.db import transaction
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
-
-from server import process_batch, versions
-
-from nudge.models import *
-
-
-from django.conf import settings
-
-import json
+from nudge import server
 
 
 @csrf_exempt
+@transaction.commit_on_success
 def batch(request):
     key = settings.NUDGE_KEY.decode('hex')
-    
-    result = process_batch(key, request.POST['batch'], request.POST['iv'])
+    result = server.process_batch(key, request.POST['batch'], request.POST['iv'])
     return HttpResponse(result)
 
 
 @csrf_exempt
 def check_versions(request):
-    keys=json.loads(request.POST[u'keys'])
-    result=versions(keys)
+    keys = json.loads(request.POST['keys'])
+    result = server.versions(keys)
     return HttpResponse(result)


### PR DESCRIPTION
Here's some things I fixed after setting up nudge for the first time and having some configuration issues.

This handles a few cases more gracefully:
- wrapping send_command in a try catch, this makes a misconfigured endpoints a bit easier to identify.
- push_one now catches the exception raised by send_command, so pushing to a misconfigured endpoint actually marks the batch as failed.
- process_batch had mixed tabs and spaces, checked a magic number and did a weird type check. Hopefully cleaned that up correctly.
- Handle a misconfigured NUDGE_SELECTIVE setting a bit more graceful, by catching ContentType.DoesNotExist and making sure all lookup values are lowercased.

Also cleans up the code of the methods I touched a bit. There were mixed tabs and spaces for example, could do a pep8 cleanup of the entire codebase if that's appreciated.
