### PR TITLE
Nudge migrations depend on reversion's.

### DIFF
--- a/src/nudge/migrations/0001_initial.py
+++ b/src/nudge/migrations/0001_initial.py
@@ -7,6 +7,10 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ('reversion', '0001_initial'),
+    )
+
     def forwards(self, orm):
         # Adding model 'BatchPushItem'
         db.create_table('nudge_batchpushitem', (


### PR DESCRIPTION
South tries to migrate nudge before migration reversion. This patch tells South that it should be the other way around.
