### PR TITLE
urls.py fix for Django 1.5

### DIFF
--- a/src/nudge/urls.py
+++ b/src/nudge/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns('nudge.views',


### PR DESCRIPTION
Fixed the `django.conf.urls` import to work with Django 1.5.  

According to the docs, this should also work with 1.4 : https://docs.djangoproject.com/en/1.4/topics/http/urls/#module-django.conf.urls
